### PR TITLE
Improve default values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,10 @@
+git formula
+==============
+
+0.0.2 (2015-01-27)
+
+- Improve default values. Git get installed using the package by default.
+
+0.0.1 (2013-06-12)
+
+- Initial version

--- a/git/map.jinja
+++ b/git/map.jinja
@@ -1,4 +1,7 @@
 {% set git = salt['grains.filter_by']({
+    'default': {
+      'install_from_source': 'False'
+    },
     'Debian': {
         'git': 'git',
     },


### PR DESCRIPTION
Currently, you must specify in a pillar whether you want to install ``git``
from the sources or from the packages. You cannot install ``git`` without having
this pillar. This is not convenient. Usually people install their software using
the packages, therefore I set the default behaviour to install ``git`` using the
packages.